### PR TITLE
Read the DHCP server information from OPTs

### DIFF
--- a/stacks/dhcp_client.go
+++ b/stacks/dhcp_client.go
@@ -222,6 +222,12 @@ func (d *DHCPClient) recv(pkt *UDPPacket) (err error) {
 			if len(opt.Data) == 1 {
 				msgType = dhcp.MessageType(opt.Data[0])
 			}
+		// The DHCP server information does not have to be in the header, but can
+		// be in the options. Copy into the decoded header for simplicity.
+		case dhcp.OptServerIdentification:
+			if len(opt.Data) == 4 {
+				copy(rcvHdr.SIAddr[:], opt.Data)
+			}
 		}
 		if debugEnabled && !internal.HeapAllocDebugging {
 			d.stack.debug("DHCP:rx", slog.String("opt", opt.Num.String()), slog.String("data", stringNumList(opt.Data)))


### PR DESCRIPTION
Not all DHCP servers will have the DHCP server address in the header of the offer, but rather in the options. When making the request, this information needs to be added to the request. The request DHCP server and the next hop does not have to be the same address or even be on the same network, so parsing these needs to be separated out.

For now, just copy in the DHCP server address from the OPTs into the read header.

I would appreciate a test of this on one of the existing networks where things have been working prior to this change.

```
$ tinygo flash -target=pico -opt=1 -stack-size=32kb -size=short -monitor  ./examples/tcpserver/
go: downloading github.com/tinygo-org/pio v0.0.0-20231216154340-cd888eb58899
   code    data     bss |   flash     ram
 569016   15740    5184 |  584756   20924
Connected to /dev/ttyACM0. Press Ctrl-C to exit.
starting program



MAC: 28:cd:c1:0d:93:c7
dhcp ongoing...
time=1970-01-01T00:00:06.968Z level=INFO msg=DHCP:tx msg=Discover
time=1970-01-01T00:00:07.018Z level=INFO msg=DHCP:rx msg=Offer
time=1970-01-01T00:00:07.019Z level=INFO msg=DHCP:tx msg=Request
time=1970-01-01T00:00:07.120Z level=INFO msg=DHCP:rx msg=Ack
DHCP complete IP: 10.0.0.26
start listening on: 10.0.0.26:1234
```