### PR TITLE
Add httpx: low memory, non-allocating http implementation

### DIFF
--- a/httpx/args.go
+++ b/httpx/args.go
@@ -1,0 +1,149 @@
+package httpx
+
+import "unsafe"
+
+const (
+	argsNoValue  = true
+	argsHasValue = false
+)
+
+type argsKV struct {
+	key     []byte
+	value   []byte
+	noValue bool
+}
+
+func visitArgs(args []argsKV, f func(k, v []byte)) {
+	for i, n := 0, len(args); i < n; i++ {
+		kv := &args[i]
+		f(kv.key, kv.value)
+	}
+}
+
+func visitArgsKey(args []argsKV, f func(k []byte)) {
+	for i, n := 0, len(args); i < n; i++ {
+		kv := &args[i]
+		f(kv.key)
+	}
+}
+
+func copyArgs(dst, src []argsKV) []argsKV {
+	if cap(dst) < len(src) {
+		tmp := make([]argsKV, len(src))
+		dstLen := len(dst)
+		dst = dst[:cap(dst)] // copy all of dst.
+		copy(tmp, dst)
+		for i := dstLen; i < len(tmp); i++ {
+			// Make sure nothing is nil.
+			tmp[i].key = []byte{}
+			tmp[i].value = []byte{}
+		}
+		dst = tmp
+	}
+	n := len(src)
+	dst = dst[:n]
+	for i := 0; i < n; i++ {
+		dstKV := &dst[i]
+		srcKV := &src[i]
+		dstKV.key = append(dstKV.key[:0], srcKV.key...)
+		if srcKV.noValue {
+			dstKV.value = dstKV.value[:0]
+		} else {
+			dstKV.value = append(dstKV.value[:0], srcKV.value...)
+		}
+		dstKV.noValue = srcKV.noValue
+	}
+	return dst
+}
+
+func delAllArgs(args []argsKV, key string) []argsKV {
+	for i, n := 0, len(args); i < n; i++ {
+		kv := &args[i]
+		if key == b2s(kv.key) {
+			tmp := *kv
+			copy(args[i:], args[i+1:])
+			n--
+			i--
+			args[n] = tmp
+			args = args[:n]
+		}
+	}
+	return args
+}
+
+func setArg(h []argsKV, key, value string, noValue bool) []argsKV {
+	n := len(h)
+	for i := 0; i < n; i++ {
+		kv := &h[i]
+		if key == b2s(kv.key) {
+			if noValue {
+				kv.value = kv.value[:0]
+			} else {
+				kv.value = append(kv.value[:0], value...)
+			}
+			kv.noValue = noValue
+			return h
+		}
+	}
+	return appendArg(h, key, value, noValue)
+}
+
+func appendArg(args []argsKV, key, value string, noValue bool) []argsKV {
+	var kv *argsKV
+	args, kv = allocArg(args)
+	kv.key = append(kv.key[:0], key...)
+	if noValue {
+		kv.value = kv.value[:0]
+	} else {
+		kv.value = append(kv.value[:0], value...)
+	}
+	kv.noValue = noValue
+	return args
+}
+
+func allocArg(h []argsKV) ([]argsKV, *argsKV) {
+	n := len(h)
+	if cap(h) > n {
+		h = h[:n+1]
+	} else {
+		h = append(h, argsKV{
+			value: []byte{},
+		})
+	}
+	return h, &h[n]
+}
+
+func releaseArg(h []argsKV) []argsKV {
+	return h[:len(h)-1]
+}
+
+func hasArg(h []argsKV, key string) bool {
+	for i, n := 0, len(h); i < n; i++ {
+		kv := &h[i]
+		if key == b2s(kv.key) {
+			return true
+		}
+	}
+	return false
+}
+
+func peekArgStr(h []argsKV, k string) []byte {
+	for i, n := 0, len(h); i < n; i++ {
+		kv := &h[i]
+		if b2s(kv.key) == k {
+			return kv.value
+		}
+	}
+	return nil
+}
+
+// b2s converts byte slice to a string without memory allocation.
+// See https://groups.google.com/forum/#!msg/Golang-Nuts/ENgbUzYvCuU/90yGx7GUAgAJ .
+func b2s(b []byte) string {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
+// s2b converts string to a byte slice without memory allocation.
+func s2b(s string) []byte {
+	return unsafe.Slice(unsafe.StringData(s), len(s))
+}

--- a/httpx/cookie.go
+++ b/httpx/cookie.go
@@ -1,0 +1,725 @@
+package httpx
+
+import (
+	"errors"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+)
+
+var zeroTime time.Time
+
+var (
+	// CookieExpireDelete may be set on Cookie.Expire for expiring the given cookie.
+	CookieExpireDelete = time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC)
+
+	// CookieExpireUnlimited indicates that the cookie doesn't expire.
+	CookieExpireUnlimited = zeroTime
+)
+
+// CookieSameSite is an enum for the mode in which the SameSite flag should be set for the given cookie.
+// See https://tools.ietf.org/html/draft-ietf-httpbis-cookie-same-site-00 for details.
+type CookieSameSite int
+
+const (
+	// CookieSameSiteDisabled removes the SameSite flag.
+	CookieSameSiteDisabled CookieSameSite = iota
+	// CookieSameSiteDefaultMode sets the SameSite flag.
+	CookieSameSiteDefaultMode
+	// CookieSameSiteLaxMode sets the SameSite flag with the "Lax" parameter.
+	CookieSameSiteLaxMode
+	// CookieSameSiteStrictMode sets the SameSite flag with the "Strict" parameter.
+	CookieSameSiteStrictMode
+	// CookieSameSiteNoneMode sets the SameSite flag with the "None" parameter.
+	// See https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
+	CookieSameSiteNoneMode
+)
+
+// AcquireCookie returns an empty Cookie object from the pool.
+//
+// The returned object may be returned back to the pool with ReleaseCookie.
+// This allows reducing GC load.
+func AcquireCookie() *Cookie {
+	return cookiePool.Get().(*Cookie)
+}
+
+// ReleaseCookie returns the Cookie object acquired with AcquireCookie back
+// to the pool.
+//
+// Do not access released Cookie object, otherwise data races may occur.
+func ReleaseCookie(c *Cookie) {
+	c.Reset()
+	cookiePool.Put(c)
+}
+
+var cookiePool = &sync.Pool{
+	New: func() any {
+		return &Cookie{}
+	},
+}
+
+// Cookie represents HTTP response cookie.
+//
+// Do not copy Cookie objects. Create new object and use CopyTo instead.
+//
+// Cookie instance MUST NOT be used from concurrently running goroutines.
+type Cookie struct {
+	noCopy noCopy
+
+	key    []byte
+	value  []byte
+	expire time.Time
+	maxAge int
+	domain []byte
+	path   []byte
+
+	httpOnly bool
+	secure   bool
+	sameSite CookieSameSite
+
+	bufKV argsKV
+	buf   []byte
+}
+
+// CopyTo copies src cookie to c.
+func (c *Cookie) CopyTo(src *Cookie) {
+	c.Reset()
+	c.key = append(c.key, src.key...)
+	c.value = append(c.value, src.value...)
+	c.expire = src.expire
+	c.maxAge = src.maxAge
+	c.domain = append(c.domain, src.domain...)
+	c.path = append(c.path, src.path...)
+	c.httpOnly = src.httpOnly
+	c.secure = src.secure
+	c.sameSite = src.sameSite
+}
+
+// HTTPOnly returns true if the cookie is http only.
+func (c *Cookie) HTTPOnly() bool {
+	return c.httpOnly
+}
+
+// SetHTTPOnly sets cookie's httpOnly flag to the given value.
+func (c *Cookie) SetHTTPOnly(httpOnly bool) {
+	c.httpOnly = httpOnly
+}
+
+// Secure returns true if the cookie is secure.
+func (c *Cookie) Secure() bool {
+	return c.secure
+}
+
+// SetSecure sets cookie's secure flag to the given value.
+func (c *Cookie) SetSecure(secure bool) {
+	c.secure = secure
+}
+
+// SameSite returns the SameSite mode.
+func (c *Cookie) SameSite() CookieSameSite {
+	return c.sameSite
+}
+
+// SetSameSite sets the cookie's SameSite flag to the given value.
+// Set value CookieSameSiteNoneMode will set Secure to true also to avoid browser rejection.
+func (c *Cookie) SetSameSite(mode CookieSameSite) {
+	c.sameSite = mode
+	if mode == CookieSameSiteNoneMode {
+		c.SetSecure(true)
+	}
+}
+
+// Path returns cookie path.
+func (c *Cookie) Path() []byte {
+	return c.path
+}
+
+// SetPath sets cookie path.
+func (c *Cookie) SetPath(path string) {
+	c.buf = append(c.buf[:0], path...)
+	c.path = normalizePath(c.path, b2s(c.buf))
+}
+
+// SetPathBytes sets cookie path.
+func (c *Cookie) SetPathBytes(path []byte) {
+	c.buf = append(c.buf[:0], path...)
+	c.path = normalizePath(c.path, b2s(c.buf))
+}
+
+// Domain returns cookie domain.
+//
+// The returned value is valid until the Cookie reused or released (ReleaseCookie).
+// Do not store references to the returned value. Make copies instead.
+func (c *Cookie) Domain() []byte {
+	return c.domain
+}
+
+// SetDomain sets cookie domain.
+func (c *Cookie) SetDomain(domain string) {
+	c.domain = append(c.domain[:0], domain...)
+}
+
+// SetDomainBytes sets cookie domain.
+func (c *Cookie) SetDomainBytes(domain []byte) {
+	c.domain = append(c.domain[:0], domain...)
+}
+
+// MaxAge returns the seconds until the cookie is meant to expire or 0
+// if no max age.
+func (c *Cookie) MaxAge() int {
+	return c.maxAge
+}
+
+// SetMaxAge sets cookie expiration time based on seconds. This takes precedence
+// over any absolute expiry set on the cookie.
+//
+// Set max age to 0 to unset.
+func (c *Cookie) SetMaxAge(seconds int) {
+	c.maxAge = seconds
+}
+
+// Expire returns cookie expiration time.
+//
+// CookieExpireUnlimited is returned if cookie doesn't expire.
+func (c *Cookie) Expire() time.Time {
+	expire := c.expire
+	if expire.IsZero() {
+		expire = CookieExpireUnlimited
+	}
+	return expire
+}
+
+// SetExpire sets cookie expiration time.
+//
+// Set expiration time to CookieExpireDelete for expiring (deleting)
+// the cookie on the client.
+//
+// By default cookie lifetime is limited by browser session.
+func (c *Cookie) SetExpire(expire time.Time) {
+	c.expire = expire
+}
+
+// Value returns cookie value.
+//
+// The returned value is valid until the Cookie reused or released (ReleaseCookie).
+// Do not store references to the returned value. Make copies instead.
+func (c *Cookie) Value() []byte {
+	return c.value
+}
+
+// SetValue sets cookie value.
+func (c *Cookie) SetValue(value string) {
+	c.value = append(c.value[:0], value...)
+}
+
+// SetValueBytes sets cookie value.
+func (c *Cookie) SetValueBytes(value []byte) {
+	c.value = append(c.value[:0], value...)
+}
+
+// Key returns cookie name.
+//
+// The returned value is valid until the Cookie reused or released (ReleaseCookie).
+// Do not store references to the returned value. Make copies instead.
+func (c *Cookie) Key() []byte {
+	return c.key
+}
+
+// SetKey sets cookie name.
+func (c *Cookie) SetKey(key string) {
+	c.key = append(c.key[:0], key...)
+}
+
+// SetKeyBytes sets cookie name.
+func (c *Cookie) SetKeyBytes(key []byte) {
+	c.key = append(c.key[:0], key...)
+}
+
+// Reset clears the cookie.
+func (c *Cookie) Reset() {
+	c.key = c.key[:0]
+	c.value = c.value[:0]
+	c.expire = zeroTime
+	c.maxAge = 0
+	c.domain = c.domain[:0]
+	c.path = c.path[:0]
+	c.httpOnly = false
+	c.secure = false
+	c.sameSite = CookieSameSiteDisabled
+}
+
+// AppendBytes appends cookie representation to dst and returns
+// the extended dst.
+func (c *Cookie) AppendBytes(dst []byte) []byte {
+	if len(c.key) > 0 {
+		dst = append(dst, c.key...)
+		dst = append(dst, '=')
+	}
+	dst = append(dst, c.value...)
+
+	if c.maxAge > 0 {
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieMaxAge...)
+		dst = append(dst, '=')
+		dst = AppendUint(dst, c.maxAge)
+	} else if !c.expire.IsZero() {
+		c.bufKV.value = AppendHTTPDate(c.bufKV.value[:0], c.expire)
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieExpires...)
+		dst = append(dst, '=')
+		dst = append(dst, c.bufKV.value...)
+	}
+	if len(c.domain) > 0 {
+		dst = appendCookiePart(dst, strCookieDomain, b2s(c.domain))
+	}
+	if len(c.path) > 0 {
+		dst = appendCookiePart(dst, strCookiePath, b2s(c.path))
+	}
+	if c.httpOnly {
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieHTTPOnly...)
+	}
+	if c.secure {
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSecure...)
+	}
+	switch c.sameSite {
+	case CookieSameSiteDefaultMode:
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSameSite...)
+	case CookieSameSiteLaxMode:
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSameSite...)
+		dst = append(dst, '=')
+		dst = append(dst, strCookieSameSiteLax...)
+	case CookieSameSiteStrictMode:
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSameSite...)
+		dst = append(dst, '=')
+		dst = append(dst, strCookieSameSiteStrict...)
+	case CookieSameSiteNoneMode:
+		dst = append(dst, ';', ' ')
+		dst = append(dst, strCookieSameSite...)
+		dst = append(dst, '=')
+		dst = append(dst, strCookieSameSiteNone...)
+	}
+	return dst
+}
+
+// Cookie returns cookie representation.
+//
+// The returned value is valid until the Cookie reused or released (ReleaseCookie).
+// Do not store references to the returned value. Make copies instead.
+func (c *Cookie) Cookie() []byte {
+	c.buf = c.AppendBytes(c.buf[:0])
+	return c.buf
+}
+
+// String returns cookie representation.
+func (c *Cookie) String() string {
+	return string(c.Cookie())
+}
+
+// WriteTo writes cookie representation to w.
+//
+// WriteTo implements io.WriterTo interface.
+func (c *Cookie) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(c.Cookie())
+	return int64(n), err
+}
+
+var errNoCookies = errors.New("no cookies found")
+
+// Parse parses Set-Cookie header.
+func (c *Cookie) Parse(src string) error {
+	c.buf = append(c.buf[:0], src...)
+	return c.ParseBytes(c.buf)
+}
+
+// ParseBytes parses Set-Cookie header.
+func (c *Cookie) ParseBytes(src []byte) error {
+	c.Reset()
+
+	var s cookieScanner
+	s.b = src
+
+	kv := &c.bufKV
+	if !s.next(kv) {
+		return errNoCookies
+	}
+
+	c.key = append(c.key, kv.key...)
+	c.value = append(c.value, kv.value...)
+
+	for s.next(kv) {
+		key := b2s(kv.key)
+		value := b2s(kv.value)
+		if len(key) != 0 {
+			// Case insensitive switch on first char
+			switch key[0] | 0x20 {
+			case 'm':
+				if caseInsensitiveCompare(strCookieMaxAge, key) {
+					maxAge, err := strconv.ParseUint(value, 10, 32)
+					if err != nil {
+						return err
+					}
+					c.maxAge = int(maxAge)
+				}
+
+			case 'e': // "expires"
+				if caseInsensitiveCompare(strCookieExpires, key) {
+
+					// Try the same two formats as net/http
+					// See: https://github.com/golang/go/blob/00379be17e63a5b75b3237819392d2dc3b313a27/src/net/http/cookie.go#L133-L135
+					exptime, err := time.ParseInLocation(time.RFC1123, value, time.UTC)
+					if err != nil {
+						exptime, err = time.Parse("Mon, 02-Jan-2006 15:04:05 MST", value)
+						if err != nil {
+							return err
+						}
+					}
+					c.expire = exptime
+				}
+
+			case 'd': // "domain"
+				if caseInsensitiveCompare(strCookieDomain, key) {
+					c.domain = append(c.domain, value...)
+				}
+
+			case 'p': // "path"
+				if caseInsensitiveCompare(strCookiePath, key) {
+					c.path = append(c.path, value...)
+				}
+
+			case 's': // "samesite"
+				if caseInsensitiveCompare(strCookieSameSite, key) {
+					if len(value) > 0 {
+						// Case insensitive switch on first char
+						switch value[0] | 0x20 {
+						case 'l': // "lax"
+							if caseInsensitiveCompare(strCookieSameSiteLax, value) {
+								c.sameSite = CookieSameSiteLaxMode
+							}
+						case 's': // "strict"
+							if caseInsensitiveCompare(strCookieSameSiteStrict, value) {
+								c.sameSite = CookieSameSiteStrictMode
+							}
+						case 'n': // "none"
+							if caseInsensitiveCompare(strCookieSameSiteNone, value) {
+								c.sameSite = CookieSameSiteNoneMode
+							}
+						}
+					}
+				}
+			}
+		} else if len(value) != 0 {
+			// Case insensitive switch on first char
+			switch value[0] | 0x20 {
+			case 'h': // "httponly"
+				if caseInsensitiveCompare(strCookieHTTPOnly, value) {
+					c.httpOnly = true
+				}
+
+			case 's': // "secure"
+				if caseInsensitiveCompare(strCookieSecure, value) {
+					c.secure = true
+				} else if caseInsensitiveCompare(strCookieSameSite, value) {
+					c.sameSite = CookieSameSiteDefaultMode
+				}
+			}
+		} // else empty or no match
+	}
+	return nil
+}
+
+func appendCookiePart(dst []byte, key, value string) []byte {
+	dst = append(dst, ';', ' ')
+	dst = append(dst, key...)
+	dst = append(dst, '=')
+	return append(dst, value...)
+}
+
+func getCookieKey(dst []byte, src string) []byte {
+	n := strings.IndexByte(src, '=')
+	if n >= 0 {
+		src = src[:n]
+	}
+	return decodeCookieArg(dst, src, false)
+}
+
+func appendRequestCookieBytes(dst []byte, cookies []argsKV) []byte {
+	for i, n := 0, len(cookies); i < n; i++ {
+		kv := &cookies[i]
+		if len(kv.key) > 0 {
+			dst = append(dst, kv.key...)
+			dst = append(dst, '=')
+		}
+		dst = append(dst, kv.value...)
+		if i+1 < n {
+			dst = append(dst, ';', ' ')
+		}
+	}
+	return dst
+}
+
+// For Response we can not use the above function as response cookies
+// already contain the key= in the value.
+func appendResponseCookieBytes(dst []byte, cookies []argsKV) []byte {
+	for i, n := 0, len(cookies); i < n; i++ {
+		kv := &cookies[i]
+		dst = append(dst, kv.value...)
+		if i+1 < n {
+			dst = append(dst, ';', ' ')
+		}
+	}
+	return dst
+}
+
+func parseRequestCookies(cookies []argsKV, src string) []argsKV {
+	var s cookieScanner
+	s.b = s2b(src)
+	var kv *argsKV
+	cookies, kv = allocArg(cookies)
+	for s.next(kv) {
+		if len(kv.key) > 0 || len(kv.value) > 0 {
+			cookies, kv = allocArg(cookies)
+		}
+	}
+	return releaseArg(cookies)
+}
+
+type cookieScanner struct {
+	b []byte
+}
+
+func (s *cookieScanner) next(kv *argsKV) bool {
+	b := b2s(s.b)
+	if len(b) == 0 {
+		return false
+	}
+
+	isKey := true
+	k := 0
+	for i, c := range b {
+		switch c {
+		case '=':
+			if isKey {
+				isKey = false
+				kv.key = decodeCookieArg(kv.key, b[:i], false)
+				k = i + 1
+			}
+		case ';':
+			if isKey {
+				kv.key = kv.key[:0]
+			}
+			kv.value = decodeCookieArg(kv.value, b[k:i], true)
+			s.b = s2b(b[i+1:])
+			return true
+		}
+	}
+
+	if isKey {
+		kv.key = kv.key[:0]
+	}
+	kv.value = decodeCookieArg(kv.value, b[k:], true)
+	s.b = s2b(b[len(b):])
+	return true
+}
+
+func decodeCookieArg(dst []byte, src string, skipQuotes bool) []byte {
+	for len(src) > 0 && src[0] == ' ' {
+		src = src[1:]
+	}
+	for len(src) > 0 && src[len(src)-1] == ' ' {
+		src = src[:len(src)-1]
+	}
+	if skipQuotes {
+		if len(src) > 1 && src[0] == '"' && src[len(src)-1] == '"' {
+			src = src[1 : len(src)-1]
+		}
+	}
+	return append(dst[:0], src...)
+}
+
+// caseInsensitiveCompare does a case insensitive equality comparison of
+// two []byte. Assumes only letters need to be matched.
+func caseInsensitiveCompare(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i]|0x20 != b[i]|0x20 {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizePath(dst []byte, src string) []byte {
+	dst = dst[:0]
+	dst = addLeadingSlash(dst, src)
+	dst = decodeArgAppendNoPlus(dst, src)
+
+	// remove duplicate slashes
+	b := dst
+	bSize := len(b)
+	for {
+		n := strings.Index(b2s(b), strSlashSlash)
+		if n < 0 {
+			break
+		}
+		b = b[n:]
+		copy(b, b[1:])
+		b = b[:len(b)-1]
+		bSize--
+	}
+	dst = dst[:bSize]
+
+	// remove /./ parts
+	b = dst
+	for {
+		n := strings.Index(b2s(b), strSlashDotSlash)
+		if n < 0 {
+			break
+		}
+		nn := n + len(strSlashDotSlash) - 1
+		copy(b[n:], b[nn:])
+		b = b[:len(b)-nn+n]
+	}
+
+	// remove /foo/../ parts
+	for {
+		n := strings.Index(b2s(b), strSlashDotDotSlash)
+		if n < 0 {
+			break
+		}
+		nn := strings.LastIndexByte(b2s(b[:n]), '/')
+		if nn < 0 {
+			nn = 0
+		}
+		n += len(strSlashDotDotSlash) - 1
+		copy(b[nn:], b[n:])
+		b = b[:len(b)-n+nn]
+	}
+
+	// remove trailing /foo/..
+	n := strings.LastIndex(b2s(b), strSlashDotDot)
+	if n >= 0 && n+len(strSlashDotDot) == len(b) {
+		nn := strings.LastIndexByte(b2s(b[:n]), '/')
+		if nn < 0 {
+			return append(dst[:0], strSlash...)
+		}
+		b = b[:nn+1]
+	}
+
+	if filepath.Separator == '\\' {
+		// remove \.\ parts
+		for {
+			n := strings.Index(b2s(b), strBackSlashDotBackSlash)
+			if n < 0 {
+				break
+			}
+			nn := n + len(strSlashDotSlash) - 1
+			copy(b[n:], b[nn:])
+			b = b[:len(b)-nn+n]
+		}
+
+		// remove /foo/..\ parts
+		for {
+			n := strings.Index(b2s(b), strSlashDotDotBackSlash)
+			if n < 0 {
+				break
+			}
+			nn := strings.LastIndexByte(b2s(b[:n]), '/')
+			if nn < 0 {
+				nn = 0
+			}
+			nn++
+			n += len(strSlashDotDotBackSlash)
+			copy(b[nn:], b[n:])
+			b = b[:len(b)-n+nn]
+		}
+
+		// remove /foo\..\ parts
+		for {
+			n := strings.Index(b2s(b), strBackSlashDotDotBackSlash)
+			if n < 0 {
+				break
+			}
+			nn := strings.LastIndexByte(b2s(b[:n]), '/')
+			if nn < 0 {
+				nn = 0
+			}
+			n += len(strBackSlashDotDotBackSlash) - 1
+			copy(b[nn:], b[n:])
+			b = b[:len(b)-n+nn]
+		}
+
+		// remove trailing \foo\..
+		n := strings.LastIndex(b2s(b), strBackSlashDotDot)
+		if n >= 0 && n+len(strSlashDotDot) == len(b) {
+			nn := strings.LastIndexByte(b2s(b[:n]), '/')
+			if nn < 0 {
+				return append(dst[:0], strSlash...)
+			}
+			b = b[:nn+1]
+		}
+	}
+
+	return b
+}
+
+func addLeadingSlash(dst []byte, src string) []byte {
+	// add leading slash for unix paths
+	if len(src) == 0 || src[0] != '/' {
+		dst = append(dst, '/')
+	}
+
+	return dst
+}
+
+// decodeArgAppendNoPlus is almost identical to decodeArgAppend, but it doesn't
+// substitute '+' with ' '.
+//
+// The function is copy-pasted from decodeArgAppend due to the performance
+// reasons only.
+func decodeArgAppendNoPlus(dst []byte, src string) []byte {
+	idx := strings.IndexByte(src, '%')
+	if idx < 0 {
+		// fast path: src doesn't contain encoded chars
+		return append(dst, src...)
+	}
+	dst = append(dst, src[:idx]...)
+
+	// slow path
+	for i := idx; i < len(src); i++ {
+		c := src[i]
+		if c == '%' {
+			if i+2 >= len(src) {
+				return append(dst, src[i:]...)
+			}
+			x2 := hex2intTable[src[i+2]]
+			x1 := hex2intTable[src[i+1]]
+			if x1 == 16 || x2 == 16 {
+				dst = append(dst, '%')
+			} else {
+				dst = append(dst, x1<<4|x2)
+				i += 2
+			}
+		} else {
+			dst = append(dst, c)
+		}
+	}
+	return dst
+}
+
+// AppendHTTPDate appends HTTP-compliant (RFC1123) representation of date
+// to dst and returns the extended dst.
+func AppendHTTPDate(dst []byte, date time.Time) []byte {
+	dst = date.In(time.UTC).AppendFormat(dst, time.RFC1123)
+	copy(dst[len(dst)-3:], strGMT)
+	return dst
+}

--- a/httpx/definitions.go
+++ b/httpx/definitions.go
@@ -1,0 +1,270 @@
+package httpx
+
+const (
+	rChar              = '\r'
+	nChar              = '\n'
+	defaultServerName  = "fasthttp"
+	defaultUserAgent   = "fasthttp"
+	defaultContentType = "text/plain; charset=utf-8"
+)
+
+const (
+	strSlash                    = "/"
+	strSlashSlash               = "//"
+	strSlashDotDot              = "/.."
+	strSlashDotSlash            = "/./"
+	strSlashDotDotSlash         = "/../"
+	strBackSlashDotDot          = `\..`
+	strBackSlashDotBackSlash    = `\.\`
+	strSlashDotDotBackSlash     = `/..\`
+	strBackSlashDotDotBackSlash = `\..\`
+	strCRLF                     = "\r\n"
+	strHTTP                     = "http"
+	strHTTPS                    = "https"
+	strHTTP10                   = "HTTP/1.0"
+	strHTTP11                   = "HTTP/1.1"
+	strColon                    = ":"
+	strColonSlashSlash          = "://"
+	strColonSpace               = ": "
+	strCommaSpace               = ", "
+	strGMT                      = "GMT"
+
+	strResponseContinue = "HTTP/1.1 100 Continue\r\n\r\n"
+
+	strExpect             = HeaderExpect
+	strConnection         = HeaderConnection
+	strContentLength      = HeaderContentLength
+	strContentType        = HeaderContentType
+	strDate               = HeaderDate
+	strHost               = HeaderHost
+	strReferer            = HeaderReferer
+	strServer             = HeaderServer
+	strTransferEncoding   = HeaderTransferEncoding
+	strContentEncoding    = HeaderContentEncoding
+	strAcceptEncoding     = HeaderAcceptEncoding
+	strUserAgent          = HeaderUserAgent
+	strCookie             = HeaderCookie
+	strSetCookie          = HeaderSetCookie
+	strLocation           = HeaderLocation
+	strIfModifiedSince    = HeaderIfModifiedSince
+	strLastModified       = HeaderLastModified
+	strAcceptRanges       = HeaderAcceptRanges
+	strRange              = HeaderRange
+	strContentRange       = HeaderContentRange
+	strAuthorization      = HeaderAuthorization
+	strTE                 = HeaderTE
+	strTrailer            = HeaderTrailer
+	strMaxForwards        = HeaderMaxForwards
+	strProxyConnection    = HeaderProxyConnection
+	strProxyAuthenticate  = HeaderProxyAuthenticate
+	strProxyAuthorization = HeaderProxyAuthorization
+	strWWWAuthenticate    = HeaderWWWAuthenticate
+	strVary               = HeaderVary
+
+	strCookieExpires        = "expires"
+	strCookieDomain         = "domain"
+	strCookiePath           = "path"
+	strCookieHTTPOnly       = "HttpOnly"
+	strCookieSecure         = "secure"
+	strCookieMaxAge         = "max-age"
+	strCookieSameSite       = "SameSite"
+	strCookieSameSiteLax    = "Lax"
+	strCookieSameSiteStrict = "Strict"
+	strCookieSameSiteNone   = "None"
+
+	strClose               = "close"
+	strGzip                = "gzip"
+	strBr                  = "br"
+	strDeflate             = "deflate"
+	strKeepAlive           = "keep-alive"
+	strUpgrade             = "Upgrade"
+	strChunked             = "chunked"
+	strIdentity            = "identity"
+	str100Continue         = "100-continue"
+	strPostArgsContentType = "application/x-www-form-urlencoded"
+	strDefaultContentType  = "application/octet-stream"
+	strMultipartFormData   = "multipart/form-data"
+	strBoundary            = "boundary"
+	strBytes               = "bytes"
+	strBasicSpace          = "Basic "
+
+	strApplicationSlash = "application/"
+	strImageSVG         = "image/svg"
+	strImageIcon        = "image/x-icon"
+	strFontSlash        = "font/"
+	strMultipartSlash   = "multipart/"
+	strTextSlash        = "text/"
+)
+
+// Headers.
+const (
+	// Authentication.
+	HeaderAuthorization      = "Authorization"
+	HeaderProxyAuthenticate  = "Proxy-Authenticate"
+	HeaderProxyAuthorization = "Proxy-Authorization"
+	HeaderWWWAuthenticate    = "WWW-Authenticate"
+
+	// Caching.
+	HeaderAge           = "Age"
+	HeaderCacheControl  = "Cache-Control"
+	HeaderClearSiteData = "Clear-Site-Data"
+	HeaderExpires       = "Expires"
+	HeaderPragma        = "Pragma"
+	HeaderWarning       = "Warning"
+
+	// Client hints.
+	HeaderAcceptCH         = "Accept-CH"
+	HeaderAcceptCHLifetime = "Accept-CH-Lifetime"
+	HeaderContentDPR       = "Content-DPR"
+	HeaderDPR              = "DPR"
+	HeaderEarlyData        = "Early-Data"
+	HeaderSaveData         = "Save-Data"
+	HeaderViewportWidth    = "Viewport-Width"
+	HeaderWidth            = "Width"
+
+	// Conditionals.
+	HeaderETag              = "ETag"
+	HeaderIfMatch           = "If-Match"
+	HeaderIfModifiedSince   = "If-Modified-Since"
+	HeaderIfNoneMatch       = "If-None-Match"
+	HeaderIfUnmodifiedSince = "If-Unmodified-Since"
+	HeaderLastModified      = "Last-Modified"
+	HeaderVary              = "Vary"
+
+	// Connection management.
+	HeaderConnection      = "Connection"
+	HeaderKeepAlive       = "Keep-Alive"
+	HeaderProxyConnection = "Proxy-Connection"
+
+	// Content negotiation.
+	HeaderAccept         = "Accept"
+	HeaderAcceptCharset  = "Accept-Charset"
+	HeaderAcceptEncoding = "Accept-Encoding"
+	HeaderAcceptLanguage = "Accept-Language"
+
+	// Controls.
+	HeaderCookie      = "Cookie"
+	HeaderExpect      = "Expect"
+	HeaderMaxForwards = "Max-Forwards"
+	HeaderSetCookie   = "Set-Cookie"
+
+	// CORS.
+	HeaderAccessControlAllowCredentials = "Access-Control-Allow-Credentials"
+	HeaderAccessControlAllowHeaders     = "Access-Control-Allow-Headers"
+	HeaderAccessControlAllowMethods     = "Access-Control-Allow-Methods"
+	HeaderAccessControlAllowOrigin      = "Access-Control-Allow-Origin"
+	HeaderAccessControlExposeHeaders    = "Access-Control-Expose-Headers"
+	HeaderAccessControlMaxAge           = "Access-Control-Max-Age"
+	HeaderAccessControlRequestHeaders   = "Access-Control-Request-Headers"
+	HeaderAccessControlRequestMethod    = "Access-Control-Request-Method"
+	HeaderOrigin                        = "Origin"
+	HeaderTimingAllowOrigin             = "Timing-Allow-Origin"
+	HeaderXPermittedCrossDomainPolicies = "X-Permitted-Cross-Domain-Policies"
+
+	// Do Not Track.
+	HeaderDNT = "DNT"
+	HeaderTk  = "Tk"
+
+	// Downloads.
+	HeaderContentDisposition = "Content-Disposition"
+
+	// Message body information.
+	HeaderContentEncoding = "Content-Encoding"
+	HeaderContentLanguage = "Content-Language"
+	HeaderContentLength   = "Content-Length"
+	HeaderContentLocation = "Content-Location"
+	HeaderContentType     = "Content-Type"
+
+	// Proxies.
+	HeaderForwarded       = "Forwarded"
+	HeaderVia             = "Via"
+	HeaderXForwardedFor   = "X-Forwarded-For"
+	HeaderXForwardedHost  = "X-Forwarded-Host"
+	HeaderXForwardedProto = "X-Forwarded-Proto"
+
+	// Redirects.
+	HeaderLocation = "Location"
+
+	// Request context.
+	HeaderFrom           = "From"
+	HeaderHost           = "Host"
+	HeaderReferer        = "Referer"
+	HeaderReferrerPolicy = "Referrer-Policy"
+	HeaderUserAgent      = "User-Agent"
+
+	// Response context.
+	HeaderAllow  = "Allow"
+	HeaderServer = "Server"
+
+	// Range requests.
+	HeaderAcceptRanges = "Accept-Ranges"
+	HeaderContentRange = "Content-Range"
+	HeaderIfRange      = "If-Range"
+	HeaderRange        = "Range"
+
+	// Security.
+	HeaderContentSecurityPolicy           = "Content-Security-Policy"
+	HeaderContentSecurityPolicyReportOnly = "Content-Security-Policy-Report-Only"
+	HeaderCrossOriginResourcePolicy       = "Cross-Origin-Resource-Policy"
+	HeaderExpectCT                        = "Expect-CT"
+	HeaderFeaturePolicy                   = "Feature-Policy"
+	HeaderPublicKeyPins                   = "Public-Key-Pins"
+	HeaderPublicKeyPinsReportOnly         = "Public-Key-Pins-Report-Only"
+	HeaderStrictTransportSecurity         = "Strict-Transport-Security"
+	HeaderUpgradeInsecureRequests         = "Upgrade-Insecure-Requests"
+	HeaderXContentTypeOptions             = "X-Content-Type-Options"
+	HeaderXDownloadOptions                = "X-Download-Options"
+	HeaderXFrameOptions                   = "X-Frame-Options"
+	HeaderXPoweredBy                      = "X-Powered-By"
+	HeaderXXSSProtection                  = "X-XSS-Protection"
+
+	// Server-sent event.
+	HeaderLastEventID = "Last-Event-ID"
+	HeaderNEL         = "NEL"
+	HeaderPingFrom    = "Ping-From"
+	HeaderPingTo      = "Ping-To"
+	HeaderReportTo    = "Report-To"
+
+	// Transfer coding.
+	HeaderTE               = "TE"
+	HeaderTrailer          = "Trailer"
+	HeaderTransferEncoding = "Transfer-Encoding"
+
+	// WebSockets.
+	HeaderSecWebSocketAccept     = "Sec-WebSocket-Accept"
+	HeaderSecWebSocketExtensions = "Sec-WebSocket-Extensions" /* #nosec G101 */
+	HeaderSecWebSocketKey        = "Sec-WebSocket-Key"
+	HeaderSecWebSocketProtocol   = "Sec-WebSocket-Protocol"
+	HeaderSecWebSocketVersion    = "Sec-WebSocket-Version"
+
+	// Other.
+	HeaderAcceptPatch         = "Accept-Patch"
+	HeaderAcceptPushPolicy    = "Accept-Push-Policy"
+	HeaderAcceptSignature     = "Accept-Signature"
+	HeaderAltSvc              = "Alt-Svc"
+	HeaderDate                = "Date"
+	HeaderIndex               = "Index"
+	HeaderLargeAllocation     = "Large-Allocation"
+	HeaderLink                = "Link"
+	HeaderPushPolicy          = "Push-Policy"
+	HeaderRetryAfter          = "Retry-After"
+	HeaderServerTiming        = "Server-Timing"
+	HeaderSignature           = "Signature"
+	HeaderSignedHeaders       = "Signed-Headers"
+	HeaderSourceMap           = "SourceMap"
+	HeaderUpgrade             = "Upgrade"
+	HeaderXDNSPrefetchControl = "X-DNS-Prefetch-Control"
+	HeaderXPingback           = "X-Pingback"
+	HeaderXRequestedWith      = "X-Requested-With"
+	HeaderXRobotsTag          = "X-Robots-Tag"
+	HeaderXUACompatible       = "X-UA-Compatible"
+)
+
+// Probably replace these with short functions to take up less program memory
+const (
+	hex2intTable                = "\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x00\x01\x02\x03\x04\x05\x06\a\b\t\x10\x10\x10\x10\x10\x10\x10\n\v\f\r\x0e\x0f\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\n\v\f\r\x0e\x0f\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10\x10"
+	toLowerTable                = "\x00\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@abcdefghijklmnopqrstuvwxyz[\\]^_`abcdefghijklmnopqrstuvwxyz{|}~\u007f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"
+	toUpperTable                = "\x00\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_`ABCDEFGHIJKLMNOPQRSTUVWXYZ{|}~\u007f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff"
+	quotedArgShouldEscapeTable  = "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x00\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x00\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+	quotedPathShouldEscapeTable = "\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x00\x01\x00\x01\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x00\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x01\x00\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\x01\x01\x00\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01\x01"
+)

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -1,6 +1,7 @@
 package httpx
 
 import (
+	"bytes"
 	"errors"
 	"net/http"
 	"strconv"
@@ -22,6 +23,7 @@ type header struct {
 	cookies              []argsKV
 	disableNormalizing   bool
 	disableSpecialHeader bool
+	noDefaultContentType bool
 	connectionClose      bool
 	noHTTP11             bool
 	cookiesCollected     bool
@@ -196,3 +198,198 @@ func isBadTrailer(key string) bool {
 	}
 	return false
 }
+
+// RawHeaders returns raw header key/value bytes.
+//
+// Depending on server configuration, header keys may be normalized to
+// capital-case in place.
+//
+// This copy is set aside during parsing, so empty slice is returned for all
+// cases where parsing did not happen. Similarly, request line is not stored
+// during parsing and can not be returned.
+//
+// The slice is not safe to use after the handler returns.
+func (h *header) RawHeaders() []byte {
+	return h.rawHeaders
+}
+
+// DisableNormalizing disables header names' normalization.
+//
+// By default all the header names are normalized by uppercasing
+// the first letter and all the first letters following dashes,
+// while lowercasing all the other letters.
+// Examples:
+//
+//   - CONNECTION -> Connection
+//   - conteNT-tYPE -> Content-Type
+//   - foo-bar-baz -> Foo-Bar-Baz
+//
+// Disable header names' normalization only if know what are you doing.
+func (h *header) DisableNormalizing() {
+	h.disableNormalizing = true
+}
+
+// DisableSpecialHeader disables special header processing.
+// fasthttp will not set any special headers for you, such as Host, Content-Type, User-Agent, etc.
+// You must set everything yourself.
+// If RequestHeader.Read() is called, special headers will be ignored.
+// This can be used to control case and order of special headers.
+// This is generally not recommended.
+func (h *header) DisableSpecialHeader() {
+	h.disableSpecialHeader = true
+}
+
+// String returns request header representation.
+func (h *header) String() string {
+	return string(h.Header())
+}
+
+// Header returns request header representation.
+//
+// Headers that set as Trailer will not represent. Use TrailerHeader for trailers.
+//
+// The returned value is valid until the request is released,
+// either though ReleaseRequest or your request handler returning.
+// Do not store references to returned value. Make copies instead.
+func (h *header) Header() []byte {
+	h.bufKV.value = h.AppendBytes(h.bufKV.value[:0])
+	return h.bufKV.value
+}
+
+// Method returns HTTP request method.
+func (h *header) Method() []byte {
+	if len(h.method) == 0 {
+		h.method = append(h.method, http.MethodGet...)
+	}
+	return h.method
+}
+
+// RequestURI returns RequestURI from the first HTTP request line.
+func (h *header) RequestURI() []byte {
+	requestURI := h.requestURI
+	if len(requestURI) == 0 {
+		requestURI = append(requestURI, '/')
+	}
+	return requestURI
+}
+
+// Protocol returns HTTP protocol.
+func (h *header) Protocol() []byte {
+	if len(h.proto) == 0 {
+		h.proto = append(h.proto, strHTTP11...)
+	}
+	return h.proto
+}
+
+// AppendBytes appends request header representation to dst and returns
+// the extended dst.
+func (h *header) AppendBytes(dst []byte) []byte {
+	dst = append(dst, h.Method()...)
+	dst = append(dst, ' ')
+	dst = append(dst, h.RequestURI()...)
+	dst = append(dst, ' ')
+	dst = append(dst, h.Protocol()...)
+	dst = append(dst, strCRLF...)
+
+	userAgent := h.UserAgent()
+	if len(userAgent) > 0 && !h.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strUserAgent, b2s(userAgent))
+	}
+
+	host := h.Host()
+	if len(host) > 0 && !h.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strHost, b2s(host))
+	}
+
+	contentType := h.ContentType()
+	if !h.noDefaultContentType && len(contentType) == 0 && !h.ignoreBody() {
+		contentType = append(contentType, strDefaultContentType...)
+	}
+	if len(contentType) > 0 && !h.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strContentType, b2s(contentType))
+	}
+	if len(h.contentLengthBytes) > 0 && !h.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strContentLength, b2s(h.contentLengthBytes))
+	}
+
+	for i, n := 0, len(h.h); i < n; i++ {
+		kv := &h.h[i]
+		// Exclude trailer from header
+		exclude := false
+		for _, t := range h.trailer {
+			if bytes.Equal(kv.key, t.key) {
+				exclude = true
+				break
+			}
+		}
+		if !exclude {
+			dst = appendHeaderLine(dst, b2s(kv.key), b2s(kv.value))
+		}
+	}
+
+	if len(h.trailer) > 0 {
+		aux := appendArgsKey(nil, h.trailer, strCommaSpace)
+		dst = appendHeaderLine(dst, strTrailer, b2s(aux))
+	}
+
+	// there is no need in h.collectCookies() here, since if cookies aren't collected yet,
+	// they all are located in h.h.
+	n := len(h.cookies)
+	if n > 0 && !h.disableSpecialHeader {
+		dst = append(dst, strCookie...)
+		dst = append(dst, strColonSpace...)
+		dst = appendRequestCookieBytes(dst, h.cookies)
+		dst = append(dst, strCRLF...)
+	}
+
+	if h.ConnectionClose() && !h.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strConnection, strClose)
+	}
+
+	return append(dst, strCRLF...)
+}
+
+func appendHeaderLine(dst []byte, key, value string) []byte {
+	dst = append(dst, key...)
+	dst = append(dst, strColonSpace...)
+	dst = append(dst, value...)
+	return append(dst, strCRLF...)
+}
+
+func (h *header) ignoreBody() bool {
+	return h.IsGet() || h.IsHead()
+}
+
+func (h *header) MethodIs(method string) bool {
+	return b2s(h.method) == method
+}
+
+// IsGet returns true if request method is GET.
+func (h *header) IsGet() bool { return len(h.method) == 0 || h.MethodIs(http.MethodGet) }
+
+// IsHead returns true if request method is HEAD.
+func (h *header) IsHead() bool { return h.MethodIs(http.MethodHead) }
+
+// IsPost returns true if request method is POST.
+func (h *header) IsPost() bool { return h.MethodIs(http.MethodPost) }
+
+// IsPut returns true if request method is PUT.
+func (h *header) IsPut() bool { return h.MethodIs(http.MethodPut) }
+
+// IsDelete returns true if request method is DELETE.
+func (h *header) IsDelete() bool { return h.MethodIs(http.MethodDelete) }
+
+// IsConnect returns true if request method is CONNECT.
+func (h *header) IsConnect() bool { return h.MethodIs(http.MethodConnect) }
+
+// IsOptions returns true if request method is OPTIONS.
+func (h *header) IsOptions() bool { return h.MethodIs(http.MethodOptions) }
+
+// IsTrace returns true if request method is TRACE.
+func (h *header) IsTrace() bool { return h.MethodIs(http.MethodTrace) }
+
+// IsPatch returns true if request method is PATCH.
+func (h *header) IsPatch() bool { return h.MethodIs(http.MethodPatch) }
+
+// IsHTTP11 returns true if the request is HTTP/1.1.
+func (h *header) IsHTTP11() bool { return !h.noHTTP11 }

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -8,6 +8,10 @@ import (
 	"strings"
 )
 
+type RequestHeader struct {
+	header
+}
+
 type header struct {
 	statusCode           int
 	contentLength        int

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -8,23 +8,27 @@ import (
 	"strings"
 )
 
+type ResponseHeader struct {
+	hdr header
+}
+
 type RequestHeader struct {
 	header
 }
 
 type header struct {
-	statusCode           int
-	contentLength        int
-	host                 []byte
-	contentLengthBytes   []byte
-	contentType          []byte
-	userAgent            []byte
-	method               []byte
-	proto                []byte
-	requestURI           []byte
-	rawHeaders           []byte
-	mulHeader            []byte
-	cookies              []argsKV
+	statusCode         int
+	contentLength      int
+	host               []byte
+	contentLengthBytes []byte
+	contentType        []byte
+	userAgent          []byte
+	method             []byte
+	proto              []byte
+	requestURI         []byte
+	rawHeaders         []byte
+	mulHeader          []byte
+
 	disableNormalizing   bool
 	disableSpecialHeader bool
 	noDefaultContentType bool
@@ -34,7 +38,9 @@ type header struct {
 	// Reusable buffer for building strings.
 	bufKV   argsKV
 	h       []argsKV
+	cookies []argsKV
 	trailer []argsKV
+	scanner headerScanner
 }
 
 func (h *header) SetContentRange(startPos, endPos, contentLength int) {

--- a/httpx/header.go
+++ b/httpx/header.go
@@ -1,0 +1,198 @@
+package httpx
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+type header struct {
+	statusCode           int
+	contentLength        int
+	host                 []byte
+	contentLengthBytes   []byte
+	contentType          []byte
+	userAgent            []byte
+	method               []byte
+	proto                []byte
+	requestURI           []byte
+	rawHeaders           []byte
+	mulHeader            []byte
+	cookies              []argsKV
+	disableNormalizing   bool
+	disableSpecialHeader bool
+	connectionClose      bool
+	noHTTP11             bool
+	cookiesCollected     bool
+	// Reusable buffer for building strings.
+	bufKV   argsKV
+	h       []argsKV
+	trailer []argsKV
+}
+
+func (h *header) SetContentRange(startPos, endPos, contentLength int) {
+	b := h.bufKV.value[:0]
+	b = append(b, strBytes...)
+	b = append(b, ' ')
+	b = AppendUint(b, startPos)
+	b = append(b, '-')
+	b = AppendUint(b, endPos)
+	b = append(b, '/')
+	b = AppendUint(b, contentLength)
+	h.bufKV.value = b
+
+	h.setNonSpecial(strContentRange, b2s(h.bufKV.value))
+}
+
+// setNonSpecial directly put into map i.e. not a basic header.
+func (h *header) setNonSpecial(key string, value string) {
+	h.h = setArg(h.h, key, value, argsHasValue)
+}
+
+// StatusCode returns response status code.
+func (h *header) StatusCode() int {
+	if h.statusCode == 0 {
+		return http.StatusOK
+	}
+	return h.statusCode
+}
+
+func AppendUint(b []byte, v int) []byte {
+	if v < 0 {
+		panic("negative uint")
+	}
+	return strconv.AppendUint(b, uint64(v), 10)
+}
+
+// ContentLength returns Content-Length header value.
+//
+// It may be negative:
+// -1 means Transfer-Encoding: chunked.
+// -2 means Transfer-Encoding: identity.
+func (h *header) ContentLength() int {
+	return h.contentLength
+}
+
+// SetContentLength sets Content-Length header value.
+//
+// Content-Length may be negative:
+// -1 means Transfer-Encoding: chunked.
+// -2 means Transfer-Encoding: identity.
+func (h *header) SetContentLength(contentLength int) {
+	h.contentLength = contentLength
+	if contentLength >= 0 {
+		h.contentLengthBytes = AppendUint(h.contentLengthBytes[:0], contentLength)
+		h.h = delAllArgs(h.h, strTransferEncoding)
+	} else {
+		h.contentLengthBytes = h.contentLengthBytes[:0]
+		h.h = setArg(h.h, strTransferEncoding, strChunked, argsHasValue)
+	}
+}
+
+var ErrBadTrailer = errors.New("contain forbidden trailer")
+
+// SetTrailer sets Trailer header value for chunked request
+// to indicate which headers will be sent after the body.
+//
+// Use Set to set the trailer header later.
+//
+// Trailers are only supported with chunked transfer.
+// Trailers allow the sender to include additional headers at the end of chunked messages.
+//
+// The following trailers are forbidden:
+// 1. necessary for message framing (e.g., Transfer-Encoding and Content-Length),
+// 2. routing (e.g., Host),
+// 3. request modifiers (e.g., controls and conditionals in Section 5 of [RFC7231]),
+// 4. authentication (e.g., see [RFC7235] and [RFC6265]),
+// 5. response control data (e.g., see Section 7.1 of [RFC7231]),
+// 6. determining how to process the payload (e.g., Content-Encoding, Content-Type, Content-Range, and Trailer)
+//
+// Return ErrBadTrailer if contain any forbidden trailers.
+func (h *header) SetTrailer(trailer string) error {
+	h.trailer = h.trailer[:0]
+	return h.AddTrailer(trailer)
+}
+
+// AddTrailerBytes add Trailer header value for chunked response
+// to indicate which headers will be sent after the body.
+//
+// Use Set to set the trailer header later.
+//
+// Trailers are only supported with chunked transfer.
+// Trailers allow the sender to include additional headers at the end of chunked messages.
+//
+// The following trailers are forbidden:
+// 1. necessary for message framing (e.g., Transfer-Encoding and Content-Length),
+// 2. routing (e.g., Host),
+// 3. request modifiers (e.g., controls and conditionals in Section 5 of [RFC7231]),
+// 4. authentication (e.g., see [RFC7235] and [RFC6265]),
+// 5. response control data (e.g., see Section 7.1 of [RFC7231]),
+// 6. determining how to process the payload (e.g., Content-Encoding, Content-Type, Content-Range, and Trailer)
+//
+// Return ErrBadTrailer if contain any forbidden trailers.
+func (h *header) AddTrailer(trailer string) error {
+	var err error
+	for i := -1; i+1 < len(trailer); {
+		trailer = trailer[i+1:]
+		i = strings.IndexByte(trailer, ',')
+		if i < 0 {
+			i = len(trailer)
+		}
+		key := stripSpace(trailer[:i])
+		// Forbidden by RFC 7230, section 4.1.2
+		if isBadTrailer(key) {
+			err = ErrBadTrailer
+			continue
+		}
+		h.bufKV.key = append(h.bufKV.key[:0], key...)
+		normalizeHeaderKey(h.bufKV.key, h.disableNormalizing)
+		h.trailer = appendArg(h.trailer, b2s(h.bufKV.key), "", argsNoValue)
+	}
+
+	return err
+}
+
+func isBadTrailer(key string) bool {
+	if len(key) == 0 {
+		return true
+	}
+
+	switch key[0] | 0x20 {
+	case 'a':
+		return caseInsensitiveCompare(key, strAuthorization)
+	case 'c':
+		if len(key) > len(HeaderContentType) && caseInsensitiveCompare(key[:8], strContentType[:8]) {
+			// skip compare prefix 'Content-'
+			return caseInsensitiveCompare(key[8:], strContentEncoding[8:]) ||
+				caseInsensitiveCompare(key[8:], strContentLength[8:]) ||
+				caseInsensitiveCompare(key[8:], strContentType[8:]) ||
+				caseInsensitiveCompare(key[8:], strContentRange[8:])
+		}
+		return caseInsensitiveCompare(key, strConnection)
+	case 'e':
+		return caseInsensitiveCompare(key, strExpect)
+	case 'h':
+		return caseInsensitiveCompare(key, strHost)
+	case 'k':
+		return caseInsensitiveCompare(key, strKeepAlive)
+	case 'm':
+		return caseInsensitiveCompare(key, strMaxForwards)
+	case 'p':
+		if len(key) > len(HeaderProxyConnection) && caseInsensitiveCompare(key[:6], strProxyConnection[:6]) {
+			// skip compare prefix 'Proxy-'
+			return caseInsensitiveCompare(key[6:], strProxyConnection[6:]) ||
+				caseInsensitiveCompare(key[6:], strProxyAuthenticate[6:]) ||
+				caseInsensitiveCompare(key[6:], strProxyAuthorization[6:])
+		}
+	case 'r':
+		return caseInsensitiveCompare(key, strRange)
+	case 't':
+		return caseInsensitiveCompare(key, strTE) ||
+			caseInsensitiveCompare(key, strTrailer) ||
+			caseInsensitiveCompare(key, strTransferEncoding)
+	case 'w':
+		return caseInsensitiveCompare(key, strWWWAuthenticate)
+	}
+	return false
+}

--- a/httpx/header_parse.go
+++ b/httpx/header_parse.go
@@ -130,8 +130,8 @@ func readRawHeaders(dst, buf []byte) ([]byte, int, error) {
 
 func (h *header) parseHeaders(buf []byte) (int, error) {
 	h.contentLength = -2
-
-	var s headerScanner
+	h.scanner = headerScanner{}
+	s := &h.scanner
 	s.b = buf
 	s.disableNormalizing = h.disableNormalizing
 	var err error

--- a/httpx/header_parse.go
+++ b/httpx/header_parse.go
@@ -1,0 +1,779 @@
+package httpx
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+)
+
+var (
+	errNeedMore        = errors.New("need more data: cannot find trailing lf")
+	errInvalidName     = errors.New("invalid header name")
+	errSmallBuffer     = errors.New("small read buffer. Increase ReadBufferSize")
+	errNonNumericChars = errors.New("non-numeric chars found")
+)
+
+type headerScanner struct {
+	b     []byte
+	key   []byte
+	value []byte
+	err   error
+
+	// hLen stores header subslice len
+	hLen int
+
+	disableNormalizing bool
+
+	// by checking whether the next line contains a colon or not to tell
+	// it's a header entry or a multi line value of current header entry.
+	// the side effect of this operation is that we know the index of the
+	// next colon and new line, so this can be used during next iteration,
+	// instead of find them again.
+	nextColon   int
+	nextNewLine int
+
+	initialized bool
+}
+
+type headerValueScanner struct {
+	b     string
+	value string
+}
+
+func (h *header) parse(buf []byte) (int, error) {
+	m, err := h.parseFirstLine(buf)
+	if err != nil {
+		return 0, err
+	}
+
+	h.rawHeaders, _, err = readRawHeaders(h.rawHeaders[:0], buf[m:])
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	n, err = h.parseHeaders(buf[m:])
+	if err != nil {
+		return 0, err
+	}
+	return m + n, nil
+}
+
+func (h *header) parseFirstLine(buf []byte) (int, error) {
+	bNext := buf
+	var b []byte
+	var err error
+	for len(b) == 0 {
+		if b, bNext, err = nextLine(bNext); err != nil {
+			return 0, err
+		}
+	}
+
+	// parse method
+	n := bytes.IndexByte(b, ' ')
+	if n <= 0 {
+		return 0, errors.New("cannot find http request method")
+	}
+	h.method = append(h.method[:0], b[:n]...)
+	b = b[n+1:]
+
+	protoStr := strHTTP11
+	// parse requestURI
+	n = bytes.LastIndexByte(b, ' ')
+	switch {
+	case n < 0:
+		h.noHTTP11 = true
+		n = len(b)
+		protoStr = strHTTP10
+	case n == 0:
+		return 0, errors.New("requestURI cannot be empty")
+	case b2s(b[n+1:]) != strHTTP11:
+		h.noHTTP11 = true
+		protoStr = b2s(b[n+1:])
+	}
+
+	h.proto = append(h.proto[:0], protoStr...)
+	h.requestURI = append(h.requestURI[:0], b[:n]...)
+
+	return len(buf) - len(bNext), nil
+}
+
+func readRawHeaders(dst, buf []byte) ([]byte, int, error) {
+	n := bytes.IndexByte(buf, nChar)
+	if n < 0 {
+		return dst[:0], 0, errNeedMore
+	}
+	if (n == 1 && buf[0] == rChar) || n == 0 {
+		// empty headers
+		return dst, n + 1, nil
+	}
+
+	n++
+	b := buf
+	m := n
+	for {
+		b = b[m:]
+		m = bytes.IndexByte(b, nChar)
+		if m < 0 {
+			return dst, 0, errNeedMore
+		}
+		m++
+		n += m
+		if (m == 2 && b[0] == rChar) || m == 1 {
+			dst = append(dst, buf[:n]...)
+			return dst, n, nil
+		}
+	}
+}
+
+func (h *header) parseHeaders(buf []byte) (int, error) {
+	h.contentLength = -2
+
+	var s headerScanner
+	s.b = buf
+	s.disableNormalizing = h.disableNormalizing
+	var err error
+	for s.next() {
+		key := b2s(s.key)
+		value := b2s(s.value)
+		if len(key) > 0 {
+			// Spaces between the header key and colon are not allowed.
+			// See RFC 7230, Section 3.2.4.
+
+			if strings.IndexByte(key, ' ') != -1 || strings.IndexByte(key, '\t') != -1 {
+				err = fmt.Errorf("invalid header key %q", s.key)
+				continue
+			}
+
+			if h.disableSpecialHeader {
+				h.h = appendArg(h.h, key, value, argsHasValue)
+				continue
+			}
+
+			switch s.key[0] | 0x20 {
+			case 'h':
+				if caseInsensitiveCompare(key, strHost) {
+					h.host = append(h.host[:0], value...)
+					continue
+				}
+			case 'u':
+				if caseInsensitiveCompare(key, strUserAgent) {
+					h.userAgent = append(h.userAgent[:0], value...)
+					continue
+				}
+			case 'c':
+				if caseInsensitiveCompare(key, strContentType) {
+					h.contentType = append(h.contentType[:0], value...)
+					continue
+				}
+				if caseInsensitiveCompare(key, strContentLength) {
+					if h.contentLength != -1 {
+						var nerr error
+						if h.contentLength, nerr = parseContentLength(s.value); nerr != nil {
+							if err == nil {
+								err = nerr
+							}
+							h.contentLength = -2
+						} else {
+							h.contentLengthBytes = append(h.contentLengthBytes[:0], value...)
+						}
+					}
+					continue
+				}
+				if caseInsensitiveCompare(key, strConnection) {
+					if b2s(s.value) == strClose {
+						h.connectionClose = true
+					} else {
+						h.connectionClose = false
+						h.h = appendArg(h.h, key, value, argsHasValue)
+					}
+					continue
+				}
+			case 't':
+				if caseInsensitiveCompare(key, strTransferEncoding) {
+					if value != strIdentity {
+						h.contentLength = -1
+						h.h = setArg(h.h, strTransferEncoding, strChunked, argsHasValue)
+					}
+					continue
+				}
+				if caseInsensitiveCompare(key, strTrailer) {
+					if nerr := h.SetTrailer(value); nerr != nil {
+						if err == nil {
+							err = nerr
+						}
+					}
+					continue
+				}
+			}
+		}
+		h.h = appendArg(h.h, key, value, argsHasValue)
+	}
+	if s.err != nil && err == nil {
+		err = s.err
+	}
+	if err != nil {
+		h.connectionClose = true
+		return 0, err
+	}
+
+	if h.contentLength < 0 {
+		h.contentLengthBytes = h.contentLengthBytes[:0]
+	}
+	if h.noHTTP11 && !h.connectionClose {
+		// close connection for non-http/1.1 request unless 'Connection: keep-alive' is set.
+		v := peekArgStr(h.h, strConnection)
+		h.connectionClose = !hasHeaderValue(b2s(v), strKeepAlive)
+	}
+	return s.hLen, nil
+}
+
+func (s *headerScanner) next() bool {
+	if !s.initialized {
+		s.nextColon = -1
+		s.nextNewLine = -1
+		s.initialized = true
+	}
+	bLen := len(s.b)
+	if bLen >= 2 && s.b[0] == rChar && s.b[1] == nChar {
+		s.b = s.b[2:]
+		s.hLen += 2
+		return false
+	}
+	if bLen >= 1 && s.b[0] == nChar {
+		s.b = s.b[1:]
+		s.hLen++
+		return false
+	}
+
+	var n int
+	if s.nextColon >= 0 {
+		n = s.nextColon
+		s.nextColon = -1
+	} else {
+		n = bytes.IndexByte(s.b, ':')
+
+		// There can't be a \n inside the header name, check for this.
+		x := bytes.IndexByte(s.b, nChar)
+		if x < 0 {
+			// A header name should always at some point be followed by a \n
+			// even if it's the one that terminates the header block.
+			s.err = errNeedMore
+			return false
+		}
+		if x < n {
+			// There was a \n before the :
+			s.err = errInvalidName
+			return false
+		}
+	}
+	if n < 0 {
+		s.err = errNeedMore
+		return false
+	}
+	s.key = s.b[:n]
+	normalizeHeaderKey(s.key, s.disableNormalizing)
+	n++
+	for len(s.b) > n && s.b[n] == ' ' {
+		n++
+		// the newline index is a relative index, and lines below trimmed `s.b` by `n`,
+		// so the relative newline index also shifted forward. it's safe to decrease
+		// to a minus value, it means it's invalid, and will find the newline again.
+		s.nextNewLine--
+	}
+	s.hLen += n
+	s.b = s.b[n:]
+	if s.nextNewLine >= 0 {
+		n = s.nextNewLine
+		s.nextNewLine = -1
+	} else {
+		n = bytes.IndexByte(s.b, nChar)
+	}
+	if n < 0 {
+		s.err = errNeedMore
+		return false
+	}
+	isMultiLineValue := false
+	for {
+		if n+1 >= len(s.b) {
+			break
+		}
+		if s.b[n+1] != ' ' && s.b[n+1] != '\t' {
+			break
+		}
+		d := bytes.IndexByte(s.b[n+1:], nChar)
+		if d <= 0 {
+			break
+		} else if d == 1 && s.b[n+1] == rChar {
+			break
+		}
+		e := n + d + 1
+		if c := bytes.IndexByte(s.b[n+1:e], ':'); c >= 0 {
+			s.nextColon = c
+			s.nextNewLine = d - c - 1
+			break
+		}
+		isMultiLineValue = true
+		n = e
+	}
+	if n >= len(s.b) {
+		s.err = errNeedMore
+		return false
+	}
+	oldB := s.b
+	s.value = s.b[:n]
+	s.hLen += n + 1
+	s.b = s.b[n+1:]
+
+	if n > 0 && s.value[n-1] == rChar {
+		n--
+	}
+	for n > 0 && s.value[n-1] == ' ' {
+		n--
+	}
+	s.value = s.value[:n]
+	if isMultiLineValue {
+		s.value, s.b, s.hLen = normalizeHeaderValue(s.value, oldB, s.hLen)
+	}
+	return true
+}
+
+func normalizeHeaderKey(b []byte, disableNormalizing bool) {
+	if disableNormalizing {
+		return
+	}
+
+	n := len(b)
+	if n == 0 {
+		return
+	}
+
+	b[0] = toUpperTable[b[0]]
+	for i := 1; i < n; i++ {
+		p := &b[i]
+		if *p == '-' {
+			i++
+			if i < n {
+				b[i] = toUpperTable[b[i]]
+			}
+			continue
+		}
+		*p = toLowerTable[*p]
+	}
+}
+
+func normalizeHeaderValue(ov, ob []byte, headerLength int) (nv, nb []byte, nhl int) {
+	nv = ov
+	length := len(ov)
+	if length <= 0 {
+		return
+	}
+	write := 0
+	shrunk := 0
+	lineStart := false
+	for read := 0; read < length; read++ {
+		c := ov[read]
+		switch {
+		case c == rChar || c == nChar:
+			shrunk++
+			if c == nChar {
+				lineStart = true
+			}
+			continue
+		case lineStart && c == '\t':
+			c = ' '
+		default:
+			lineStart = false
+		}
+		nv[write] = c
+		write++
+	}
+
+	nv = nv[:write]
+	copy(ob[write:], ob[write+shrunk:])
+
+	// Check if we need to skip \r\n or just \n
+	skip := 0
+	if ob[write] == rChar {
+		if ob[write+1] == nChar {
+			skip += 2
+		} else {
+			skip++
+		}
+	} else if ob[write] == nChar {
+		skip++
+	}
+
+	nb = ob[write+skip : len(ob)-shrunk]
+	nhl = headerLength - shrunk
+	return
+}
+
+// caseInsensitiveCompare does a case insensitive equality comparison of
+// two []byte. Assumes only letters need to be matched.
+func caseInsensitiveCompare(a, b string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := 0; i < len(a); i++ {
+		if a[i]|0x20 != b[i]|0x20 {
+			return false
+		}
+	}
+	return true
+}
+
+func parseContentLength(b []byte) (int, error) {
+	v, n, err := parseUintBuf(b)
+	if err != nil {
+		return -1, fmt.Errorf("cannot parse Content-Length: %w", err)
+	}
+	if n != len(b) {
+		return -1, fmt.Errorf("cannot parse Content-Length: %w", errNonNumericChars)
+	}
+	return v, nil
+}
+
+func hasHeaderValue(s, value string) bool {
+	var vs headerValueScanner
+	vs.b = s
+	for vs.next() {
+		if caseInsensitiveCompare(vs.value, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *headerValueScanner) next() bool {
+	b := s.b
+	if len(b) == 0 {
+		return false
+	}
+	n := strings.IndexByte(b, ',')
+	if n < 0 {
+		s.value = stripSpace(b)
+		s.b = b[len(b):]
+		return true
+	}
+	s.value = stripSpace(b[:n])
+	s.b = b[n+1:]
+	return true
+}
+
+func nextLine(b []byte) ([]byte, []byte, error) {
+	nNext := bytes.IndexByte(b, nChar)
+	if nNext < 0 {
+		return nil, nil, errNeedMore
+	}
+	n := nNext
+	if n > 0 && b[n-1] == rChar {
+		n--
+	}
+	return b[:n], b[nNext+1:], nil
+}
+
+func stripSpace(b string) string {
+	for len(b) > 0 && b[0] == ' ' {
+		b = b[1:]
+	}
+	for len(b) > 0 && b[len(b)-1] == ' ' {
+		b = b[:len(b)-1]
+	}
+	return b
+}
+
+var (
+	errEmptyInt               = errors.New("empty integer")
+	errUnexpectedFirstChar    = errors.New("unexpected first char found. Expecting 0-9")
+	errUnexpectedTrailingChar = errors.New("unexpected trailing char found. Expecting 0-9")
+	errTooLongInt             = errors.New("too long int")
+)
+
+func parseUintBuf(b []byte) (int, int, error) {
+	n := len(b)
+	if n == 0 {
+		return -1, 0, errEmptyInt
+	}
+	v := 0
+	for i := 0; i < n; i++ {
+		c := b[i]
+		k := c - '0'
+		if k > 9 {
+			if i == 0 {
+				return -1, i, errUnexpectedFirstChar
+			}
+			return v, i, nil
+		}
+		vNew := 10*v + int(k)
+		// Test for overflow.
+		if vNew < v {
+			return -1, i, errTooLongInt
+		}
+		v = vNew
+	}
+	return v, n, nil
+}
+
+/*
+
+Request Parsing
+
+*/
+
+// Read reads request header from r.
+//
+// io.EOF is returned if r is closed before reading the first header byte.
+func (h *header) Read(r *bufio.Reader) error {
+	return h.readLoop(r, true)
+}
+
+// readLoop reads request header from r optionally loops until it has enough data.
+//
+// io.EOF is returned if r is closed before reading the first header byte.
+func (h *header) readLoop(r *bufio.Reader, waitForMore bool) error {
+	n := 1
+	for {
+		err := h.tryRead(r, n)
+		if err == nil {
+			return nil
+		}
+		if !waitForMore || err != errNeedMore {
+			h.resetSkipNormalize()
+			return err
+		}
+		n = r.Buffered() + 1
+	}
+}
+
+func (h *header) tryRead(r *bufio.Reader, n int) error {
+	h.resetSkipNormalize()
+	b, err := r.Peek(n)
+	if len(b) == 0 {
+		if err == io.EOF {
+			return err
+		}
+
+		if err == nil {
+			panic("bufio.Reader.Peek() returned nil, nil")
+		}
+
+		// This is for go 1.6 bug. See https://github.com/golang/go/issues/14121 .
+		if err == bufio.ErrBufferFull {
+			return &ErrSmallBuffer{
+				error: fmt.Errorf("error when reading request headers: %w (n=%d, r.Buffered()=%d)", errSmallBuffer, n, r.Buffered()),
+			}
+		}
+
+		// n == 1 on the first read for the request.
+		if n == 1 {
+			// We didn't read a single byte.
+			return ErrNothingRead{err}
+		}
+
+		return fmt.Errorf("error when reading request headers: %w", err)
+	}
+	b = mustPeekBuffered(r)
+	headersLen, errParse := h.parse(b)
+	if errParse != nil {
+		return headerError("request", err, errParse, b, false)
+	}
+	mustDiscard(r, headersLen)
+	return nil
+}
+
+func (h *header) resetSkipNormalize() {
+	h.noHTTP11 = false
+	h.connectionClose = false
+
+	h.contentLength = 0
+	h.contentLengthBytes = h.contentLengthBytes[:0]
+
+	h.method = h.method[:0]
+	h.proto = h.proto[:0]
+	h.requestURI = h.requestURI[:0]
+	h.host = h.host[:0]
+	h.contentType = h.contentType[:0]
+	h.userAgent = h.userAgent[:0]
+	h.trailer = h.trailer[:0]
+	h.mulHeader = h.mulHeader[:0]
+
+	h.h = h.h[:0]
+	h.cookies = h.cookies[:0]
+	h.cookiesCollected = false
+
+	h.rawHeaders = h.rawHeaders[:0]
+}
+
+func headerError(typ string, err, errParse error, b []byte, secureErrorLogMessage bool) error {
+	if errParse != errNeedMore {
+		return headerErrorMsg(typ, errParse, b, secureErrorLogMessage)
+	}
+	if err == nil {
+		return errNeedMore
+	}
+
+	// Buggy servers may leave trailing CRLFs after http body.
+	// Treat this case as EOF.
+	if isOnlyCRLF(b) {
+		return io.EOF
+	}
+
+	if err != bufio.ErrBufferFull {
+		return headerErrorMsg(typ, err, b, secureErrorLogMessage)
+	}
+	return &ErrSmallBuffer{
+		error: headerErrorMsg(typ, errSmallBuffer, b, secureErrorLogMessage),
+	}
+}
+
+func isOnlyCRLF(b []byte) bool {
+	for _, ch := range b {
+		if ch != rChar && ch != nChar {
+			return false
+		}
+	}
+	return true
+}
+func headerErrorMsg(typ string, err error, b []byte, secureErrorLogMessage bool) error {
+	return fmt.Errorf("error when reading %s headers: %w. Buffer size=%d", typ, err, len(b))
+}
+
+// ErrNothingRead is returned when a keep-alive connection is closed,
+// either because the remote closed it or because of a read timeout.
+type ErrNothingRead struct {
+	error
+}
+
+// ErrSmallBuffer is returned when the provided buffer size is too small
+// for reading request and/or response headers.
+//
+// ReadBufferSize value from Server or clients should reduce the number
+// of such errors.
+type ErrSmallBuffer struct {
+	error
+}
+
+func mustPeekBuffered(r *bufio.Reader) []byte {
+	buf, err := r.Peek(r.Buffered())
+	if len(buf) == 0 || err != nil {
+		panic(fmt.Sprintf("bufio.Reader.Peek() returned unexpected data (%q, %v)", buf, err))
+	}
+	return buf
+}
+
+func mustDiscard(r *bufio.Reader, n int) {
+	if _, err := r.Discard(n); err != nil {
+		panic(fmt.Sprintf("bufio.Reader.Discard(%d) failed: %v", n, err))
+	}
+}
+
+// Peek returns header value for the given key.
+//
+// The returned value is valid until the request is released,
+// either though ReleaseRequest or your request handler returning.
+// Do not store references to returned value. Make copies instead.
+func (h *header) Peek(key string) []byte {
+	k := getHeaderKeyBytes(&h.bufKV, key, h.disableNormalizing)
+	return h.peek(b2s(k))
+}
+
+// Host returns Host header value.
+func (h *header) Host() []byte {
+	if h.disableSpecialHeader {
+		return peekArg(h.h, HeaderHost)
+	}
+	return h.host
+}
+
+func getHeaderKeyBytes(kv *argsKV, key string, disableNormalizing bool) []byte {
+	kv.key = append(kv.key[:0], key...)
+	normalizeHeaderKey(kv.key, disableNormalizing)
+	return kv.key
+}
+
+func peekArg(h []argsKV, k string) []byte {
+	for i, n := 0, len(h); i < n; i++ {
+		kv := &h[i]
+		if b2s(kv.key) == k {
+			return kv.value
+		}
+	}
+	return nil
+}
+
+func (h *header) peek(key string) []byte {
+	switch key {
+	case HeaderHost:
+		return h.Host()
+	case HeaderContentType:
+		return h.ContentType()
+	case HeaderUserAgent:
+		return h.UserAgent()
+	case HeaderConnection:
+		if h.ConnectionClose() {
+			return []byte(strClose)
+		}
+		return peekArg(h.h, key)
+	case HeaderContentLength:
+		return h.contentLengthBytes
+	case HeaderCookie:
+		if h.cookiesCollected {
+			return appendRequestCookieBytes(nil, h.cookies)
+		}
+		return peekArg(h.h, key)
+	case HeaderTrailer:
+		return appendArgsKey(nil, h.trailer, strCommaSpace)
+	default:
+		return peekArg(h.h, key)
+	}
+}
+
+// ContentType returns Content-Type header value.
+func (h *header) ContentType() []byte {
+	if h.disableSpecialHeader {
+		return peekArg(h.h, HeaderContentType)
+	}
+	return h.contentType
+}
+
+// ConnectionClose returns true if 'Connection: close' header is set.
+func (h *header) ConnectionClose() bool {
+	return h.connectionClose
+}
+
+// UserAgent returns User-Agent header value.
+func (h *header) UserAgent() []byte {
+	if h.disableSpecialHeader {
+		return peekArg(h.h, HeaderUserAgent)
+	}
+	return h.userAgent
+}
+
+func appendRequestCookieBytes(dst []byte, cookies []argsKV) []byte {
+	for i, n := 0, len(cookies); i < n; i++ {
+		kv := &cookies[i]
+		if len(kv.key) > 0 {
+			dst = append(dst, kv.key...)
+			dst = append(dst, '=')
+		}
+		dst = append(dst, kv.value...)
+		if i+1 < n {
+			dst = append(dst, ';', ' ')
+		}
+	}
+	return dst
+}
+
+func appendArgsKey(dst []byte, args []argsKV, sep string) []byte {
+	for i, n := 0, len(args); i < n; i++ {
+		kv := &args[i]
+		dst = append(dst, kv.key...)
+		if i+1 < n {
+			dst = append(dst, sep...)
+		}
+	}
+	return dst
+}

--- a/httpx/header_request.go
+++ b/httpx/header_request.go
@@ -1,0 +1,82 @@
+package httpx
+
+import "bufio"
+
+type RequestHeader struct {
+	hdr header
+}
+
+// Read reads request header from r.
+//
+// io.EOF is returned if r is closed before reading the first header byte.
+func (h *RequestHeader) Read(r *bufio.Reader) error {
+	return h.hdr.readLoop(r, true)
+}
+
+func (h *RequestHeader) Host() []byte { return h.hdr.Host() }
+
+func (h *RequestHeader) Peek(key string) []byte { return h.hdr.Peek(key) }
+
+func (h *RequestHeader) RawHeaders() []byte { return h.hdr.RawHeaders() }
+
+func (h *RequestHeader) DisableNormalizing() { h.hdr.DisableNormalizing() }
+
+func (h *RequestHeader) Method() []byte { return h.hdr.Method() }
+
+func (h *RequestHeader) RequestURI() []byte { return h.hdr.RequestURI() }
+
+func (h *RequestHeader) Protocol() []byte      { return h.hdr.Protocol() }
+func (h *RequestHeader) UserAgent() []byte     { return h.hdr.UserAgent() }
+func (h *RequestHeader) ContentType() []byte   { return h.hdr.ContentType() }
+func (h *RequestHeader) DisableSpecialHeader() { h.hdr.DisableSpecialHeader() }
+
+// String returns request header representation.
+func (h *RequestHeader) String() string {
+	return string(h.Header())
+}
+
+// Header returns request header representation.
+//
+// Headers that set as Trailer will not represent. Use TrailerHeader for trailers.
+//
+// The returned value is valid until the request is released,
+// either though ReleaseRequest or your request handler returning.
+// Do not store references to returned value. Make copies instead.
+func (h *RequestHeader) Header() []byte {
+	h.hdr.bufKV.value = h.AppendBytes(h.hdr.bufKV.value[:0])
+	return h.hdr.bufKV.value
+}
+
+// AppendBytes appends request header representation to dst and returns
+// the extended dst.
+func (h *RequestHeader) AppendBytes(dst []byte) []byte {
+	dst = append(dst, h.Method()...)
+	dst = append(dst, ' ')
+	dst = append(dst, h.RequestURI()...)
+	dst = append(dst, ' ')
+	dst = append(dst, h.Protocol()...)
+	dst = append(dst, strCRLF...)
+
+	userAgent := h.UserAgent()
+	if len(userAgent) > 0 && !h.hdr.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strUserAgent, b2s(userAgent))
+	}
+
+	host := h.Host()
+	if len(host) > 0 && !h.hdr.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strHost, b2s(host))
+	}
+
+	contentType := h.ContentType()
+	if !h.hdr.noDefaultContentType && len(contentType) == 0 && !h.hdr.ignoreBody() {
+		contentType = append(contentType, strDefaultContentType...)
+	}
+	if len(contentType) > 0 && !h.hdr.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strContentType, b2s(contentType))
+	}
+	if len(h.hdr.contentLengthBytes) > 0 && !h.hdr.disableSpecialHeader {
+		dst = appendHeaderLine(dst, strContentLength, b2s(h.hdr.contentLengthBytes))
+	}
+
+	return h.hdr.AppendReqRespCommon(dst)
+}

--- a/httpx/header_response.go
+++ b/httpx/header_response.go
@@ -1,0 +1,204 @@
+package httpx
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+type ResponseHeader struct {
+	statusCode    int
+	server        []byte
+	statusMessage []byte
+	now           time.Time
+	hdr           header
+}
+
+func (h *ResponseHeader) serverTime() time.Time {
+	if !h.now.IsZero() {
+		return h.now
+	}
+	return time.Now()
+}
+
+// Reset clears response header. It is ready for new use after returning from Reset.
+func (h *ResponseHeader) Reset() {
+	h.hdr.disableNormalizing = false
+	// h.SetNoDefaultContentType(false)
+	// h.noDefaultDate = false
+	h.server = h.server[:0]
+	h.statusMessage = h.statusMessage[:0]
+	h.statusCode = 0
+	h.hdr.resetSkipNormalize()
+}
+
+// SetContentType sets Content-Type header value. i.e: "text/html; charset=utf-8"
+func (h *ResponseHeader) SetContentType(contentType string) {
+	h.hdr.SetContentType(contentType)
+}
+
+// SetContentLength sets Content-Length header value.
+func (h *ResponseHeader) SetContentLength(contentLength int) {
+	h.hdr.SetContentLength(contentLength)
+}
+
+// Server returns Server header value.
+func (h *ResponseHeader) Server() []byte { return h.server }
+
+// SetServer sets Server header value.
+func (h *ResponseHeader) SetServer(server string) {
+	h.server = append(h.server[:0], server...)
+}
+
+// StatusCode returns response status code.
+func (h *ResponseHeader) StatusCode() int {
+	if h.statusCode == 0 {
+		return http.StatusOK
+	}
+	return h.statusCode
+}
+
+// StatusMessage returns response status message.
+func (h *ResponseHeader) StatusMessage() []byte {
+	return h.statusMessage
+}
+
+// Write writes response header to w.
+func (h *ResponseHeader) Write(w *bufio.Writer) error {
+	_, err := w.Write(h.Header())
+	return err
+}
+
+// WriteTo writes response header to w.
+//
+// WriteTo implements io.WriterTo interface.
+func (h *ResponseHeader) WriteTo(w io.Writer) (int64, error) {
+	n, err := w.Write(h.Header())
+	return int64(n), err
+}
+
+// Header returns response header representation.
+//
+// Headers that set as Trailer will not represent. Use TrailerHeader for trailers.
+//
+// The returned value is valid until the request is released,
+// either though ReleaseRequest or your request handler returning.
+// Do not store references to returned value. Make copies instead.
+func (h *ResponseHeader) Header() []byte {
+	h.hdr.bufKV.value = h.AppendBytes(h.hdr.bufKV.value[:0])
+	return h.hdr.bufKV.value
+}
+
+// SetStatusCode sets response status code. If not set will default to 200 (Status OK).
+func (h *ResponseHeader) SetStatusCode(statusCode int) {
+	h.statusCode = statusCode
+}
+
+// SetConnectionClose sets 'Connection: close' header.
+func (h *ResponseHeader) SetConnectionClose() {
+	h.hdr.SetConnectionClose()
+}
+
+// Add adds the given 'key: value' header.
+//
+// Multiple headers with the same key may be added with this function.
+// Use SetBytesKV for setting a single header for the given key.
+//
+// the Content-Type, Content-Length, Connection, Server, Set-Cookie,
+// Transfer-Encoding and Date headers can only be set once and will
+// overwrite the previous value.
+//
+// If the header is set as a Trailer (forbidden trailers will not be set, see AddTrailer for more details),
+// it will be sent after the chunked response body.
+func (h *ResponseHeader) Add(key, value string) {
+	h.hdr.Add(key, value)
+}
+
+// Peek returns header value for the given key.
+//
+// The returned value is valid until the response is released,
+// either though ReleaseResponse or your request handler returning.
+// Do not store references to the returned value. Make copies instead.
+func (h *ResponseHeader) Peek(key string) []byte {
+	return h.hdr.Peek(key)
+}
+
+// AppendBytes appends response header representation to dst and returns
+// the extended dst.
+func (h *ResponseHeader) AppendBytes(dst []byte) []byte {
+	dst = h.appendStatusLine(dst[:0])
+
+	server := h.Server()
+	if len(server) != 0 {
+		dst = appendHeaderLine(dst, strServer, b2s(server))
+	}
+
+	// if !h.noDefaultDate {
+	// now := h.serverTime()
+	// now.AppendFormat()
+	// serverDateOnce.Do(updateServerDate)
+	// dst = appendHeaderLine(dst, strDate, serverDate.Load().([]byte))
+	// }
+
+	// Append Content-Type only for non-zero responses
+	// or if it is explicitly set.
+	// See https://github.com/valyala/fasthttp/issues/28 .
+	if h.hdr.ContentLength() != 0 || len(h.hdr.contentType) > 0 {
+		contentType := h.hdr.ContentType()
+		if len(contentType) > 0 {
+			dst = appendHeaderLine(dst, strContentType, b2s(contentType))
+		}
+	}
+	contentEncoding := h.hdr.ContentEncoding()
+	if len(contentEncoding) > 0 {
+		dst = appendHeaderLine(dst, strContentEncoding, b2s(contentEncoding))
+	}
+
+	if len(h.hdr.contentLengthBytes) > 0 {
+		dst = appendHeaderLine(dst, strContentLength, b2s(h.hdr.contentLengthBytes))
+	}
+
+	return h.hdr.AppendReqRespCommon(dst)
+}
+
+// appendStatusLine appends the response status line to dst and returns
+// the extended dst.
+func (h *ResponseHeader) appendStatusLine(dst []byte) []byte {
+	statusCode := h.StatusCode()
+	if statusCode < 0 {
+		statusCode = 200
+	}
+	return formatStatusLine(dst, h.hdr.Protocol(), statusCode, h.StatusMessage())
+}
+
+func formatStatusLine(dst []byte, protocol []byte, statusCode int, statusText []byte) []byte {
+	dst = append(dst, protocol...)
+	dst = append(dst, ' ')
+	dst = strconv.AppendInt(dst, int64(statusCode), 10)
+	dst = append(dst, ' ')
+	if len(statusText) == 0 {
+		dst = append(dst, StatusMessage(statusCode)...)
+	} else {
+		dst = append(dst, statusText...)
+	}
+	return append(dst, strCRLF...)
+}
+
+// StatusMessage returns HTTP status message for the given status code.
+func StatusMessage(statusCode int) string {
+	const (
+		statusMessageMin  = 100
+		statusMessageMax  = 511
+		unknownStatusCode = "Unknown Status Code"
+	)
+	if statusCode < statusMessageMin || statusCode > statusMessageMax {
+		return unknownStatusCode
+	}
+
+	if s := http.StatusText(statusCode); s != "" {
+		return s
+	}
+	return unknownStatusCode
+}

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -4,8 +4,31 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"strings"
 	"testing"
 )
+
+func TestResponseHeaderAddContentType(t *testing.T) {
+	t.Parallel()
+
+	var h ResponseHeader
+	h.Add("Content-Type", "test")
+
+	got := string(h.Peek("Content-Type"))
+	expected := "test"
+	if got != expected {
+		t.Errorf("expected %q got %q", expected, got)
+	}
+
+	var buf bytes.Buffer
+	if _, err := h.WriteTo(&buf); err != nil {
+		t.Fatalf("unexpected error when writing header: %v", err)
+	}
+
+	if n := strings.Count(buf.String(), "Content-Type: "); n != 1 {
+		t.Errorf("Content-Type occurred %d times", n)
+	}
+}
 
 func TestRequestHeaderEmptyValueFromString(t *testing.T) {
 	t.Parallel()
@@ -144,7 +167,7 @@ func TestRequestDisableSpecialHeaders(t *testing.T) {
 	}
 	// assert order of all headers preserved
 	if h.String() != s {
-		t.Fatalf("Headers not equal: %q. Expecting %q", h.String(), s)
+		t.Fatalf("Headers not equal:\n%q\nExpecting:\n%q\n", h.String(), s)
 	}
 	// h.SetCanonical([]byte("host"), []byte("notfoobar"))
 	// if string(h.Host()) != "foobar" {

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -1,0 +1,33 @@
+package httpx
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+)
+
+func TestRequestHeaderEmptyValueFromString(t *testing.T) {
+	t.Parallel()
+
+	s := "GET / HTTP/1.1\r\n" +
+		"EmptyValue1:\r\n" +
+		"Host: foobar\r\n" +
+		"EmptyValue2: \r\n" +
+		"\r\n"
+	var h header
+	br := bufio.NewReader(bytes.NewBufferString(s))
+	if err := h.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(h.Host()) != "foobar" {
+		t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+	}
+	v1 := h.Peek("EmptyValue1")
+	if len(v1) > 0 {
+		t.Fatalf("expecting empty value. Got %q", v1)
+	}
+	v2 := h.Peek("EmptyValue2")
+	if len(v2) > 0 {
+		t.Fatalf("expecting empty value. Got %q", v2)
+	}
+}

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -3,6 +3,7 @@ package httpx
 import (
 	"bufio"
 	"bytes"
+	"fmt"
 	"testing"
 )
 
@@ -30,4 +31,126 @@ func TestRequestHeaderEmptyValueFromString(t *testing.T) {
 	if len(v2) > 0 {
 		t.Fatalf("expecting empty value. Got %q", v2)
 	}
+}
+
+func TestRequestRawHeaders(t *testing.T) {
+	t.Parallel()
+
+	kvs := "hOsT: foobar\r\n" +
+		"value:  b\r\n" +
+		"\r\n"
+	t.Run("normalized", func(t *testing.T) {
+		s := "GET / HTTP/1.1\r\n" + kvs
+		exp := kvs
+		var h header
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(h.Host()) != "foobar" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+		}
+		v2 := h.Peek("Value")
+		if !bytes.Equal(v2, []byte{'b'}) {
+			t.Fatalf("expecting non empty value. Got %q", v2)
+		}
+		if raw := h.RawHeaders(); string(raw) != exp {
+			t.Fatalf("expected header %q, got %q", exp, raw)
+		}
+	})
+	for _, n := range []int{0, 1, 4, 8} {
+		t.Run(fmt.Sprintf("post-%dk", n), func(t *testing.T) {
+			l := 1024 * n
+			body := make([]byte, l)
+			for i := range body {
+				body[i] = 'a'
+			}
+			cl := fmt.Sprintf("Content-Length: %d\r\n", l)
+			s := "POST / HTTP/1.1\r\n" + cl + kvs + string(body)
+			exp := cl + kvs
+			var h header
+			br := bufio.NewReader(bytes.NewBufferString(s))
+			if err := h.Read(br); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(h.Host()) != "foobar" {
+				t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+			}
+			v2 := h.Peek("Value")
+			if !bytes.Equal(v2, []byte{'b'}) {
+				t.Fatalf("expecting non empty value. Got %q", v2)
+			}
+			if raw := h.RawHeaders(); string(raw) != exp {
+				t.Fatalf("expected header %q, got %q", exp, raw)
+			}
+		})
+	}
+	t.Run("http10", func(t *testing.T) {
+		s := "GET / HTTP/1.0\r\n" + kvs
+		exp := kvs
+		var h header
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(h.Host()) != "foobar" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "foobar")
+		}
+		v2 := h.Peek("Value")
+		if !bytes.Equal(v2, []byte{'b'}) {
+			t.Fatalf("expecting non empty value. Got %q", v2)
+		}
+		if raw := h.RawHeaders(); string(raw) != exp {
+			t.Fatalf("expected header %q, got %q", exp, raw)
+		}
+	})
+	t.Run("no-kvs", func(t *testing.T) {
+		s := "GET / HTTP/1.1\r\n\r\n"
+		exp := ""
+		var h header
+		h.DisableNormalizing()
+		br := bufio.NewReader(bytes.NewBufferString(s))
+		if err := h.Read(br); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(h.Host()) != "" {
+			t.Fatalf("unexpected host: %q. Expecting %q", h.Host(), "")
+		}
+		v1 := h.Peek("NoKey")
+		if len(v1) > 0 {
+			t.Fatalf("expecting empty value. Got %q", v1)
+		}
+		if raw := h.RawHeaders(); string(raw) != exp {
+			t.Fatalf("expected header %q, got %q", exp, raw)
+		}
+	})
+}
+
+func TestRequestDisableSpecialHeaders(t *testing.T) {
+	t.Parallel()
+
+	kvs := "Host: foobar\r\n" +
+		"User-Agent: ua\r\n" +
+		"Non-Special: val\r\n" +
+		"\r\n"
+
+	var h header
+	h.DisableSpecialHeader()
+
+	s := "GET / HTTP/1.0\r\n" + kvs
+	br := bufio.NewReader(bytes.NewBufferString(s))
+	if err := h.Read(br); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// assert order of all headers preserved
+	if h.String() != s {
+		t.Fatalf("Headers not equal: %q. Expecting %q", h.String(), s)
+	}
+	// h.SetCanonical([]byte("host"), []byte("notfoobar"))
+	// if string(h.Host()) != "foobar" {
+	// 	t.Fatalf("unexpected: %q. Expecting %q", h.Host(), "foobar")
+	// }
+	// if h.String() != "GET / HTTP/1.0\r\nHost: foobar\r\nUser-Agent: ua\r\nNon-Special: val\r\nhost: notfoobar\r\n\r\n" {
+	// 	t.Fatalf("custom special header ordering failed: %q", h.String())
+	// }
 }

--- a/httpx/header_test.go
+++ b/httpx/header_test.go
@@ -15,7 +15,7 @@ func TestRequestHeaderEmptyValueFromString(t *testing.T) {
 		"Host: foobar\r\n" +
 		"EmptyValue2: \r\n" +
 		"\r\n"
-	var h header
+	var h RequestHeader
 	br := bufio.NewReader(bytes.NewBufferString(s))
 	if err := h.Read(br); err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -42,7 +42,7 @@ func TestRequestRawHeaders(t *testing.T) {
 	t.Run("normalized", func(t *testing.T) {
 		s := "GET / HTTP/1.1\r\n" + kvs
 		exp := kvs
-		var h header
+		var h RequestHeader
 		br := bufio.NewReader(bytes.NewBufferString(s))
 		if err := h.Read(br); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -88,7 +88,7 @@ func TestRequestRawHeaders(t *testing.T) {
 	t.Run("http10", func(t *testing.T) {
 		s := "GET / HTTP/1.0\r\n" + kvs
 		exp := kvs
-		var h header
+		var h RequestHeader
 		br := bufio.NewReader(bytes.NewBufferString(s))
 		if err := h.Read(br); err != nil {
 			t.Fatalf("unexpected error: %v", err)
@@ -107,7 +107,7 @@ func TestRequestRawHeaders(t *testing.T) {
 	t.Run("no-kvs", func(t *testing.T) {
 		s := "GET / HTTP/1.1\r\n\r\n"
 		exp := ""
-		var h header
+		var h RequestHeader
 		h.DisableNormalizing()
 		br := bufio.NewReader(bytes.NewBufferString(s))
 		if err := h.Read(br); err != nil {
@@ -134,7 +134,7 @@ func TestRequestDisableSpecialHeaders(t *testing.T) {
 		"Non-Special: val\r\n" +
 		"\r\n"
 
-	var h header
+	var h RequestHeader
 	h.DisableSpecialHeader()
 
 	s := "GET / HTTP/1.0\r\n" + kvs

--- a/internal/backoff.go
+++ b/internal/backoff.go
@@ -1,0 +1,59 @@
+package internal
+
+import "time"
+
+type BackoffFlags uint8
+
+const (
+	BackoffHasPriority BackoffFlags = 1 << iota
+	BackoffCriticalPath
+)
+
+func NewBackoff(priority BackoffFlags) Backoff {
+	if priority&BackoffCriticalPath != 0 {
+		return Backoff{
+			maxWait: uint32(1 * time.Millisecond),
+		}
+	}
+	return Backoff{
+		maxWait: uint32(time.Second) >> (priority & BackoffHasPriority),
+	}
+}
+
+// A Backoff with a non-zero MaxWait is ready for use.
+type Backoff struct {
+	// wait defines the amount of time that Miss will wait on next call.
+	wait uint32
+	// Maximum allowable value for Wait.
+	maxWait uint32
+	// startWait is the value that Wait takes after a call to Hit.
+	startWait uint32
+	// expMinusOne is the shift performed on Wait minus one, so the zero value performs a shift of 1.
+	expMinusOne uint32
+}
+
+// Hit sets eb.Wait to the StartWait value.
+func (eb *Backoff) Hit() {
+	if eb.maxWait == 0 {
+		panic("MaxWait cannot be zero")
+	}
+	eb.wait = eb.startWait
+}
+
+// Miss sleeps for eb.Wait and increases eb.Wait exponentially.
+func (eb *Backoff) Miss() {
+	const k = 1
+	wait := eb.wait
+	maxWait := eb.maxWait
+	exp := eb.expMinusOne + 1
+	if maxWait == 0 {
+		panic("MaxWait cannot be zero")
+	}
+	time.Sleep(time.Duration(wait))
+	wait |= k
+	wait <<= exp
+	if wait > maxWait {
+		wait = maxWait
+	}
+	eb.wait = wait
+}

--- a/stacks/port_tcp.go
+++ b/stacks/port_tcp.go
@@ -202,6 +202,15 @@ func prand16(seed uint16) uint16 {
 	return seed
 }
 
+// prand32 generates a pseudo random number from a seed.
+func prand32[T ~uint32](seed T) T {
+	/* Algorithm "xor" from p. 4 of Marsaglia, "Xorshift RNGs" */
+	seed ^= seed << 13
+	seed ^= seed >> 17
+	seed ^= seed << 5
+	return seed
+}
+
 // ParseTCPPacket is a convenience function for generating a pkt TCP packet
 //
 // Deprecated: This function is guaranteed to disappear in the future. Used only in tests.


### PR DESCRIPTION
Inspired entirely by the excellent fasthttp library: https://github.com/valyala/fasthttp/blob/master/header.go

Some notable changes to the base fasthttp library:
* Reduce stack usage by changing most internal `[]byte` usage to `string`
* Trying to go for a single `header` type that condenses most HTTP logic, including response and requests
* Trying best to reduce the resulting size of program whenever possible
* Change some logic that allocates in TinyGo but does not in upstream Go


Still learning a lot about http while writing this, most likely will change.