### PR TITLE
set closing field on Closing state to prevent forever open connections

### DIFF
--- a/stacks/tcpconn.go
+++ b/stacks/tcpconn.go
@@ -303,6 +303,10 @@ func (sock *TCPConn) Close() error {
 	if toSend == 0 {
 		err := sock.scb.Close()
 		if err != nil {
+			if sock.scb.State().IsClosing() {
+				// TODO(soypat): FinWait2 and Timewait would prevent socket from closing indefinetely if it were not for this.
+				sock.closing = true
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
Title says it. Before this PR TCP connections could remain in an open state if hitting FinWait2. Calling close would not prevent it.